### PR TITLE
Edited library/src/flexlib/controls/iconLoaderClasses/IcoParser.as via Gi

### DIFF
--- a/library/src/flexlib/controls/iconLoaderClasses/IcoParser.as
+++ b/library/src/flexlib/controls/iconLoaderClasses/IcoParser.as
@@ -1,25 +1,35 @@
-/*
-Copyright (c) 2007 FlexLib Contributors.  See:
-    http://code.google.com/p/flexlib/wiki/ProjectContributors
+/**
+ * -----------------------------------------------------------------------
+ * Windows Icon Parser.
+ * -----------------------------------------------------------------------
+ * Copyright (c) 2007 FlexLib Contributors.  See:
+ *     http://code.google.com/p/flexlib/wiki/ProjectContributors
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * 
+ * -----------------------------------------------------------------------
+ * This is a modified version of the IconParser class from flexlib. I have
+ * extended the class to handle all bpp (bits per pixel) types 4, 8, 24
+ * and 32.
+ * -----------------------------------------------------------------------
+ */
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-*/
 
 package flexlib.controls.iconLoaderClasses
 {
@@ -28,6 +38,8 @@ package flexlib.controls.iconLoaderClasses
 	import flash.utils.Endian;
 	import flash.utils.Dictionary;
 	import flash.geom.Rectangle;
+	import flash.display.FrameLabel;
+	
 	
 	/**
 	 * A parser for the Windows .ico icon file.
@@ -40,7 +52,7 @@ package flexlib.controls.iconLoaderClasses
 		/**
 		 * @inheritDoc
 		 */
-		 
+
 		public function get validIcon() : Boolean
 		{
 			return _validIcon;
@@ -80,7 +92,6 @@ package flexlib.controls.iconLoaderClasses
 		/**
 		 * Constructor
 		 */
-		 
 		public function IcoParser() 
 		{
 		}
@@ -91,6 +102,8 @@ package flexlib.controls.iconLoaderClasses
 		 
 		public function parse() : void
 		{			
+	        _data.position = 0;
+	        
 			_validIcon = parseHeader();
 			
 			if( _validIcon )
@@ -109,27 +122,38 @@ package flexlib.controls.iconLoaderClasses
 		 
 		public function getIconForSize( s : int ) : BitmapData
 		{
-			if( _sizes.indexOf( s ) == -1 )
-			{				
-				var oldS	: int = s;
-				
-				for each( s  in _sizes )
-				{
-					if( s < oldS )
+			var result:BitmapData = null; 
+					
+			try
+			{
+				if( _sizes.indexOf( s ) == -1 )
+				{				
+					var oldS	: int = s;
+					
+					for each( s  in _sizes )
 					{
-						break;
+						if( s < oldS )
+						{
+							break;
+						}
 					}
 				}
+				
+				result = new BitmapData( s, s );
+				var icon	: IconImage = _iconImages[ s ] as IconImage;
+				var ba		: ByteArray = processImage( icon.icXOR );
+							
+				ba.position = 0;			
+				result.setPixels( new Rectangle( 0, 0, s, s ), ba );
+				
+				mirrorBitmap( result );
+				
+				return result;
 			}
-			
-			var result	: BitmapData = new BitmapData( s, s );
-			var icon	: IconImage = _iconImages[ s ] as IconImage;
-			var ba		: ByteArray = processImage( icon.icXOR );
-						
-			ba.position = 0;			
-			result.setPixels( new Rectangle( 0, 0, s, s ), ba );
-			
-			mirrorBitmap( result );
+			catch (e:Error)
+			{
+				trace(e);
+			}
 			
 			return result;
 		}
@@ -159,7 +183,7 @@ package flexlib.controls.iconLoaderClasses
 		 * Reads the directory information for each icon in the icon data
 		 */
 		 
-		private function parseIconDirs() : Boolean
+		private function parseIconDirs():Boolean
 		{
 			for( var i : int = 0; i < _numIcons; i++ )
 			{
@@ -179,61 +203,22 @@ package flexlib.controls.iconLoaderClasses
 			
 			return true;
 		}
+
 		
 		/**
 		 * @private
 		 * Reads icon information and bitmap data for each icon directory in the icon data
 		 */
 		 
-		private function parseIconImages() : Boolean
+		private function parseIconImages():Boolean
 		{
 			for each( var dir : IconDirEntry in _iconDirEntries )
 			{
 				_data.position = dir.dwImageOffset;
 				
-				var header	: BitmapInfoHeader = new BitmapInfoHeader();
+				var header:BitmapInfoHeader = loadHeader(_data);
 				
-				header.biSize = _data.readUnsignedInt();
-				header.biWidth = _data.readUnsignedInt();
-				header.biHeight = _data.readUnsignedInt();
-				header.biPlanes = _data.readUnsignedShort();
-				header.biBitCount = _data.readUnsignedShort();
-				header.biCompression = _data.readUnsignedInt();
-				header.biSizeImage = _data.readUnsignedInt();
-				header.biXPelsPerMeter = _data.readUnsignedInt();
-				header.biYPelsPerMeter = _data.readUnsignedInt();
-				header.biClrUsed = _data.readUnsignedInt();
-				header.biClrImportant = _data.readUnsignedInt();
-								
-				//--	No support yet for bpp < 24
-				
-				if( header.biBitCount < 24 )
-				{
-					_data.position = dir.dwImageOffset + dir.dwBytesInRes;
-					continue;
-				}
-								
-				var iconImage	: IconImage = new IconImage();
-				
-				iconImage.icHeader = header;
-				iconImage.icAND = new ByteArray();
-				iconImage.icXOR = new ByteArray();
-				
-				//--	Skip the color table
-				
-				var colorTableLen	: int = 0;
-				
-				if( header.biBitCount == 32 && header.biCompression == BI_BITFIELDS )
-				{
-					colorTableLen = 12;	// 3 DWORDS
-				}
-				
-				_data.position += colorTableLen;
-				
-				var imageLen	: int = ( ( header.biHeight / 2 ) * header.biWidth ) * 4;
-				iconImage.icXOR.writeBytes( _data, _data.position, imageLen );
-				
-				//--	Don't bother reading the AND data -- we're not going to use it.
+				var iconImage:IconImage  = loadIconImage(dir, header, _data);
 				
 				_iconImages[ dir.bWidth ] = iconImage;
 				_sizes.push( dir.bWidth );
@@ -242,12 +227,227 @@ package flexlib.controls.iconLoaderClasses
 			
 			return true;
 		}
+
+		/**
+		 * Load bitmap header
+		 * 
+		 * @param values ByteArray of bitmap contents.
+		 * 
+		 */
+		private function loadHeader(values:ByteArray):BitmapInfoHeader
+		{
+			// Build Header
+			var header	: BitmapInfoHeader = new BitmapInfoHeader();
+			
+			header.biSize = values.readUnsignedInt();
+			header.biWidth = values.readUnsignedInt();
+			header.biHeight = values.readUnsignedInt();
+			header.biPlanes = values.readUnsignedShort();
+			header.biBitCount = values.readUnsignedShort();
+			header.biCompression = values.readUnsignedInt();
+			header.biSizeImage = values.readUnsignedInt();
+			header.biXPelsPerMeter = values.readUnsignedInt();
+			header.biYPelsPerMeter = values.readUnsignedInt();
+			header.biClrUsed = values.readUnsignedInt();
+			header.biClrImportant = values.readUnsignedInt();
+				
+			return header;			
+		}
+		
+		/**
+		 * Load icon image from data.
+		 * 
+		 * @param Image directory structure.
+		 * @param Image header structure.
+ 		 * @param Image values.
+ 		 * 
+		 */
+		private function loadIconImage(dir:IconDirEntry, header:BitmapInfoHeader, values:ByteArray):IconImage		
+		{
+			var iconImage:IconImage = new IconImage();
+
+			iconImage.icHeader = header;
+			iconImage.icColors = new ByteArray();
+			iconImage.icAND = new ByteArray();
+			iconImage.icXOR = new ByteArray();
+			
+			// From the directory image starting point, jump past the header, there be the colour table.
+			var colorTableIndex:int = dir.dwImageOffset+header.biSize;
+			var sizeColorTable:int = 0;
+			
+			var sizeImage:int = ( ( header.biHeight / 2 ) * header.biWidth );
+
+			if (header.biBitCount<24)
+			{
+				// Deal with colour table if it's used.
+				var numColors:int = header.biClrUsed;
+				
+				if (numColors==0)
+				{
+			      	numColors = (1 << header.biBitCount);
+				}
+				
+				sizeColorTable = numColors * 4;
+	
+				// Write the colour table
+				iconImage.icColors.writeBytes(values, colorTableIndex, sizeColorTable);
+			}
+			
+			// Because it's in the directory we have to jump to the start of the image proper.
+			var fromIndex:int = colorTableIndex+sizeColorTable;
+			
+			switch (header.biBitCount)
+			{
+				case 1:
+				break;
+				
+				case 4:
+					readImage4(values, fromIndex, sizeImage, iconImage);
+				break;
+				
+				case 8:
+					readImage8(values, fromIndex, sizeImage, iconImage);
+				break;
+				
+				case 24:
+					readImage24(values, fromIndex, sizeImage, iconImage);
+				break;
+				
+				case 32:
+				default:
+					readImage32(values, fromIndex, sizeImage, iconImage);
+				break;
+			}
+			
+			return iconImage;
+		}
+		
+		/**
+		 * Read image from data.
+		 * 
+		 * @param ByteArray of data.
+		 * @param Index of starting positon in values.
+		 * @param Size of image in bytes.
+		 * @param Icon object to load image to.
+		 * 
+		 */
+		private function readImage4(values:ByteArray, fromIndex:int, sizeImage:int, image:IconImage):void
+		{
+			values.position = fromIndex;
+			var pixelIndex:int = sizeImage;
+			while (pixelIndex!=0)
+			{
+				var value:int = values.readUnsignedByte()&0xFF;
+				
+				for (var nibbleIndex:int=1; nibbleIndex>=0; nibbleIndex--)
+				{
+					var nibble:int = 0;
+					if (nibbleIndex&1)
+					{
+						nibble  = (value&0xF0)>>>4;
+					}
+					else
+					{
+						nibble = (value&0x0F);
+					}
+					
+					var row:int = nibble*4;
+					
+					// Use loaded colour table as lookup for rgb values.
+					var r:int = image.icColors[row];
+					var g:int = image.icColors[row+1];
+					var b:int = image.icColors[row+2];
+	
+					image.icXOR.writeByte(r);
+					image.icXOR.writeByte(g);
+					image.icXOR.writeByte(b);
+					image.icXOR.writeByte(255);
+				}
+				
+				pixelIndex -=2; // Goes down twice as fast
+			}
+		}
+		
+		/**
+		 * Read image from data.
+		 * 
+		 * @param ByteArray of data.
+		 * @param Index of starting positon in values.
+		 * @param Size of image in bytes.
+		 * @param Icon object to load image to.
+		 * 
+		 */
+		private function readImage8(values:ByteArray, fromIndex:int, sizeImage:int, image:IconImage):void
+		{
+			values.position = fromIndex;
+			var pixelIndex:int = sizeImage;
+			while (pixelIndex!=0)
+			{
+				var value:int = values.readUnsignedByte()&0xFF;
+				
+				var row:int = value*4;
+				
+				// Use loaded colour table as lookup for rgb values.
+				var r:int = image.icColors[row];
+				var g:int = image.icColors[row+1];
+				var b:int = image.icColors[row+2];
+
+				image.icXOR.writeByte(r);
+				image.icXOR.writeByte(g);
+				image.icXOR.writeByte(b);
+				image.icXOR.writeByte(255);
+
+				pixelIndex--;
+			}
+		}		
+
+		/**
+		 * Read image from data.
+		 * 
+		 * @param ByteArray of data.
+		 * @param Index of starting positon in values.
+		 * @param Size of image in bytes.
+		 * @param Icon object to load image to.
+		 * 
+		 */
+		private function readImage24(values:ByteArray, fromIndex:int, sizeImage:int, image:IconImage):void
+		{
+			values.position = fromIndex;
+			var pixelIndex:int = sizeImage;
+			while (pixelIndex!=0)
+			{
+				var value1:int = values.readUnsignedByte()&0xFF;
+				var value2:int = values.readUnsignedByte()&0xFF;
+				var value3:int = values.readUnsignedByte()&0xFF;
+				
+				image.icXOR.writeByte(value1);
+				image.icXOR.writeByte(value2);
+				image.icXOR.writeByte(value3);
+				image.icXOR.writeByte(255);
+
+				pixelIndex--;
+			}
+		}
+				
+		/**
+		 * Read image from data.
+		 * 
+		 * @param ByteArray of data.
+		 * @param Index of starting positon in values.
+		 * @param Size of image in bytes.
+		 * @param Icon object to load image to.
+		 * 
+		 */
+		private function readImage32(values:ByteArray, fromIndex:int, sizeImage:int, image:IconImage):void
+		{
+			// Oh so simple.
+			image.icXOR.writeBytes(values, fromIndex, sizeImage*4);
+		}
 		
 		/**
 		 * @private
 		 * Converts each byte in the icon's XOR data from BGRA to ARGB.
 		 */
-		
 		private function processImage( bm : ByteArray ) : ByteArray
 		{
 			var result	: ByteArray = new ByteArray();


### PR DESCRIPTION
Edited library/src/flexlib/controls/iconLoaderClasses/IcoParser.as via GitHub

I have extended the class to handle all bpp (bits per pixel) types 4, 8, 24 and 32. I have had this kicking around my hard disk for ages so now I can finally submit it back to flexlib.
