### PR TITLE
Flex 4 Style Fixes

### DIFF
--- a/library/src/flexlib/charts/DraggablePie.as
+++ b/library/src/flexlib/charts/DraggablePie.as
@@ -25,9 +25,10 @@ package flexlib.charts
     import flash.events.Event;
     import flash.events.MouseEvent;
     import flash.geom.Point;
-
+    
     import flexlib.charts.utils.GeomUtils;
-
+    import flexlib.styles.StyleDeclarationHelper;
+    
     import mx.collections.ArrayCollection;
     import mx.collections.ICollectionView;
     import mx.core.FlexGlobals;
@@ -136,7 +137,10 @@ package flexlib.charts
 
         private static function constructStyle():Boolean
         {
-            var style:CSSStyleDeclaration = FlexGlobals.topLevelApplication.styleManager.getStyleDeclaration("DraggablePie");
+            var style:CSSStyleDeclaration = FlexGlobals.topLevelApplication.styleManager.getStyleDeclaration(
+				StyleDeclarationHelper.getStyleSelectorForClassName("flexlib.charts.DraggablePie")
+			);
+			
             if(style)
             {
                 if(style.getStyle("disabledAlpha") == undefined)
@@ -164,7 +168,10 @@ package flexlib.charts
                     this.lineColor = 0x333333;
                 };
             }
-            FlexGlobals.topLevelApplication.styleManager.setStyleDeclaration("DraggablePie",style,true);
+            FlexGlobals.topLevelApplication.styleManager.setStyleDeclaration(
+				StyleDeclarationHelper.getStyleSelectorForClassName("flexlib.charts.DraggablePie")
+				,style,true);
+			
             return true;
         }
 

--- a/library/src/flexlib/charts/HorizontalAxisDataSelector.as
+++ b/library/src/flexlib/charts/HorizontalAxisDataSelector.as
@@ -28,7 +28,9 @@ package flexlib.charts
   import flash.events.Event;
   import flash.events.MouseEvent;
   import flash.geom.Point;
-
+  
+  import flexlib.styles.StyleDeclarationHelper;
+  
   import mx.charts.chartClasses.ChartElement;
   import mx.core.EventPriority;
   import mx.core.FlexGlobals;
@@ -72,14 +74,16 @@ package flexlib.charts
     /** Initialize styles to default values */
     private static function classConstruct():Boolean
     {
-      if (!FlexGlobals.topLevelApplication.styleManager.getStyleDeclaration("HorizontalAxisDataSelector"))
+      if (!FlexGlobals.topLevelApplication.styleManager.getStyleDeclaration(StyleDeclarationHelper.getStyleSelectorForClassName("flexlib.charts.HorizontalAxisDataSelector")))
       {
         // If HorizontalAxisDataSelector has no CSS definition,
         // create one and set the default value.
         var newStyleDeclaration:CSSStyleDeclaration = new CSSStyleDeclaration();
         newStyleDeclaration.setStyle("selectorColor", 0xFF0000);
 
-        FlexGlobals.topLevelApplication.styleManager.setStyleDeclaration("HorizontalAxisDataSelector", newStyleDeclaration, true);
+        FlexGlobals.topLevelApplication.styleManager.setStyleDeclaration(
+			StyleDeclarationHelper.getStyleSelectorForClassName("flexlib.charts.HorizontalAxisDataSelector"), 
+			newStyleDeclaration, true);
       }
       return true;
     }

--- a/library/src/flexlib/containers/ButtonScrollingCanvas.as
+++ b/library/src/flexlib/containers/ButtonScrollingCanvas.as
@@ -28,11 +28,13 @@ package flexlib.containers
 	import flash.events.MouseEvent;
 	import flash.events.TimerEvent;
 	import flash.utils.Timer;
-
+	
+	import flexlib.styles.StyleDeclarationHelper;
+	
 	import mx.containers.Canvas;
 	import mx.controls.Button;
-    import mx.core.FlexGlobals;
-    import mx.core.ScrollPolicy;
+	import mx.core.FlexGlobals;
+	import mx.core.ScrollPolicy;
 	import mx.styles.CSSStyleDeclaration;
 
 
@@ -114,7 +116,9 @@ package flexlib.containers
 		 */
 		private static function initializeStyles():void
 		{
-			var selector:CSSStyleDeclaration = FlexGlobals.topLevelApplication.styleManager.getStyleDeclaration("ButtonScrollingCanvas");
+			var selector:CSSStyleDeclaration = FlexGlobals.topLevelApplication.styleManager.getStyleDeclaration(
+				StyleDeclarationHelper.getStyleSelectorForClassName("flexlib.containers.ButtonScrollingCanvas")
+			);
 
 			if(!selector)
 			{
@@ -129,7 +133,9 @@ package flexlib.containers
 				this.rightButtonStyleName = "rightButton";
 			}
 
-			FlexGlobals.topLevelApplication.styleManager.setStyleDeclaration("ButtonScrollingCanvas", selector, false);
+			FlexGlobals.topLevelApplication.styleManager.setStyleDeclaration(
+				StyleDeclarationHelper.getStyleSelectorForClassName("flexlib.containers.ButtonScrollingCanvas"), 
+				selector, false);
 
 
 

--- a/library/src/flexlib/containers/HAccordion.as
+++ b/library/src/flexlib/containers/HAccordion.as
@@ -23,21 +23,21 @@ SOFTWARE.
 
 package flexlib.containers
 {
-	import flexlib.baseClasses.AccordionBase;
-
 	import flash.geom.Rectangle;
-
+	
+	import flexlib.baseClasses.AccordionBase;
+	import flexlib.containers.accordionClasses.AccordionHeaderLocation;
+	import flexlib.styles.StyleDeclarationHelper;
+	
 	import mx.controls.Button;
 	import mx.core.Container;
 	import mx.core.EdgeMetrics;
-    import mx.core.FlexGlobals;
-    import mx.core.IUIComponent;
+	import mx.core.FlexGlobals;
+	import mx.core.IUIComponent;
 	import mx.core.UIComponent;
 	import mx.core.mx_internal;
 	import mx.effects.Tween;
 	import mx.styles.CSSStyleDeclaration;
-
-	import flexlib.containers.accordionClasses.AccordionHeaderLocation;
 
 	use namespace mx_internal;
 
@@ -62,7 +62,9 @@ package flexlib.containers
 	{
 		private static function initializeStyles():void
 		{
-			var selector:CSSStyleDeclaration = FlexGlobals.topLevelApplication.styleManager.getStyleDeclaration("HAccordion");
+			var selector:CSSStyleDeclaration = FlexGlobals.topLevelApplication.styleManager.getStyleDeclaration(
+				StyleDeclarationHelper.getStyleSelectorForClassName("flexlib.containers.HAccordion")
+			);
 
 			if(!selector)
 			{
@@ -81,7 +83,9 @@ package flexlib.containers
 				this.horizontalGap = -1;
 			}
 
-			FlexGlobals.topLevelApplication.styleManager.setStyleDeclaration("HAccordion", selector, false);
+			FlexGlobals.topLevelApplication.styleManager.setStyleDeclaration(
+				StyleDeclarationHelper.getStyleSelectorForClassName("flexlib.containers.HAccordion"), 
+				selector, false);
 
 		}
 

--- a/library/src/flexlib/containers/SuperTabNavigator.as
+++ b/library/src/flexlib/containers/SuperTabNavigator.as
@@ -27,14 +27,15 @@ package flexlib.containers
   import flash.display.DisplayObject;
   import flash.events.Event;
   import flash.events.MouseEvent;
-
+  
   import flexlib.controls.ScrollableArrowMenu;
   import flexlib.controls.SuperTabBar;
   import flexlib.controls.tabBarClasses.SuperTab;
   import flexlib.events.SuperTabEvent;
   import flexlib.events.TabReorderEvent;
   import flexlib.skins.TabPopUpButtonSkin;
-
+  import flexlib.styles.StyleDeclarationHelper;
+  
   import mx.collections.ArrayCollection;
   import mx.collections.IList;
   import mx.containers.Box;
@@ -500,7 +501,9 @@ package flexlib.containers
      */
     private static function initializeStyles():void
     {
-      var selector:CSSStyleDeclaration = FlexGlobals.topLevelApplication.styleManager.getStyleDeclaration("SuperTabNavigator");
+      var selector:CSSStyleDeclaration = FlexGlobals.topLevelApplication.styleManager.getStyleDeclaration(
+		  StyleDeclarationHelper.getStyleSelectorForClassName("flexlib.containers.SuperTabNavigator")
+	  );
 
       if (!selector)
       {
@@ -615,7 +618,9 @@ package flexlib.containers
 
 
 
-      FlexGlobals.topLevelApplication.styleManager.setStyleDeclaration("SuperTabNavigator", selector, false);
+      FlexGlobals.topLevelApplication.styleManager.setStyleDeclaration(
+		  StyleDeclarationHelper.getStyleSelectorForClassName("flexlib.containers.SuperTabNavigator"), 
+		  selector, false);
 
 
     }

--- a/library/src/flexlib/containers/VAccordion.as
+++ b/library/src/flexlib/containers/VAccordion.as
@@ -23,18 +23,19 @@ SOFTWARE.
 
 package flexlib.containers
 {
+	import flash.geom.Rectangle;
+	
 	import flexlib.baseClasses.AccordionBase;
 	import flexlib.containers.accordionClasses.AccordionHeaderLocation;
-
-	import flash.geom.Rectangle;
-
+	import flexlib.styles.StyleDeclarationHelper;
+	
 	import mx.controls.Button;
 	import mx.core.Container;
 	import mx.core.EdgeMetrics;
-    import mx.core.FlexGlobals;
-    import mx.core.IUIComponent;
-	import mx.core.mx_internal;
+	import mx.core.FlexGlobals;
+	import mx.core.IUIComponent;
 	import mx.core.UIComponent;
+	import mx.core.mx_internal;
 	import mx.styles.CSSStyleDeclaration;
 
 
@@ -55,7 +56,9 @@ package flexlib.containers
 
 		private static function initializeStyles():void
 		{
-			var selector:CSSStyleDeclaration = FlexGlobals.topLevelApplication.styleManager.getStyleDeclaration("VAccordion");
+			var selector:CSSStyleDeclaration = FlexGlobals.topLevelApplication.styleManager.getStyleDeclaration(
+				StyleDeclarationHelper.getStyleSelectorForClassName("flexlib.containers.VAccordion")
+			);
 
 			if(!selector)
 			{
@@ -74,7 +77,9 @@ package flexlib.containers
 				this.horizontalGap = -1;
 			}
 
-			FlexGlobals.topLevelApplication.styleManager.setStyleDeclaration("VAccordion", selector, false);
+			FlexGlobals.topLevelApplication.styleManager.setStyleDeclaration(
+				StyleDeclarationHelper.getStyleSelectorForClassName("flexlib.containers.VAccordion"), 
+				selector, false);
 
 		}
 

--- a/library/src/flexlib/containers/WindowShade.as
+++ b/library/src/flexlib/containers/WindowShade.as
@@ -22,20 +22,21 @@ SOFTWARE.
 */
 package flexlib.containers {
 	import flash.events.MouseEvent;
-    import flexlib.events.WindowShadeEvent;
-
+	
+	import flexlib.events.WindowShadeEvent;
+	import flexlib.styles.StyleDeclarationHelper;
+	
 	import mx.controls.Button;
 	import mx.core.EdgeMetrics;
-    import mx.core.FlexGlobals;
-    import mx.core.IFactory;
+	import mx.core.FlexGlobals;
+	import mx.core.IFactory;
 	import mx.core.LayoutContainer;
 	import mx.core.ScrollPolicy;
 	import mx.effects.Resize;
-    import mx.effects.effectClasses.ResizeInstance;
-    import mx.events.EffectEvent;
-    import mx.events.PropertyChangeEvent;
+	import mx.effects.effectClasses.ResizeInstance;
+	import mx.events.EffectEvent;
+	import mx.events.PropertyChangeEvent;
 	import mx.styles.CSSStyleDeclaration;
-
 	import mx.utils.StringUtil;
 
     /**
@@ -171,7 +172,10 @@ package flexlib.containers {
 
         private static function constructClass():Boolean {
 
-            var css:CSSStyleDeclaration = FlexGlobals.topLevelApplication.styleManager.getStyleDeclaration("WindowShade")
+            var css:CSSStyleDeclaration = FlexGlobals.topLevelApplication.styleManager.getStyleDeclaration(
+				StyleDeclarationHelper.getStyleSelectorForClassName("flexlib.containers.WindowShade")
+			);
+			
             var changed:Boolean = false;
             if(!css) {
                 // If there is no CSS definition for WindowShade,
@@ -189,7 +193,9 @@ package flexlib.containers {
             }
 
             if(changed) {
-                FlexGlobals.topLevelApplication.styleManager.setStyleDeclaration("WindowShade", css, true);
+                FlexGlobals.topLevelApplication.styleManager.setStyleDeclaration(
+					StyleDeclarationHelper.getStyleSelectorForClassName("flexlib.containers.WindowShade"), 
+					css, true);
             }
 
             return true;

--- a/library/src/flexlib/containers/accordionClasses/CanvasButtonAccordionHeader.as
+++ b/library/src/flexlib/containers/accordionClasses/CanvasButtonAccordionHeader.as
@@ -13,16 +13,18 @@ package flexlib.containers.accordionClasses
 import flash.display.DisplayObject;
 import flash.events.Event;
 import flash.events.MouseEvent;
+
+import flexlib.controls.CanvasButton;
+import flexlib.styles.StyleDeclarationHelper;
+
 import mx.core.Container;
 import mx.core.FlexGlobals;
 import mx.core.IDataRenderer;
 import mx.core.IFlexDisplayObject;
 import mx.core.mx_internal;
+import mx.skins.halo.AccordionHeaderSkin;
 import mx.styles.CSSStyleDeclaration;
 import mx.styles.ISimpleStyleClient;
-
-import flexlib.controls.CanvasButton;
-import mx.skins.halo.AccordionHeaderSkin;
 
 use namespace mx_internal;
 
@@ -139,7 +141,9 @@ public class CanvasButtonAccordionHeader extends CanvasButton implements IDataRe
 
 	private static function initializeStyles():void
 	{
-		var selector:CSSStyleDeclaration = FlexGlobals.topLevelApplication.styleManager.getStyleDeclaration("CanvasButtonAccordionHeader");
+		var selector:CSSStyleDeclaration = FlexGlobals.topLevelApplication.styleManager.getStyleDeclaration(
+			StyleDeclarationHelper.getStyleSelectorForClassName("flexlib.containers.accordionClasses.CanvasButtonAccordionHeader")
+		);
 
 		if(!selector)
 		{
@@ -165,8 +169,9 @@ public class CanvasButtonAccordionHeader extends CanvasButton implements IDataRe
 			this.upSkin = mx.skins.halo.AccordionHeaderSkin;
 		}
 
-		FlexGlobals.topLevelApplication.styleManager.setStyleDeclaration("CanvasButtonAccordionHeader", selector, false);
-
+		FlexGlobals.topLevelApplication.styleManager.setStyleDeclaration(
+			StyleDeclarationHelper.getStyleSelectorForClassName("flexlib.containers.accordionClasses.CanvasButtonAccordionHeader"), 
+			selector, false);
 	}
 
 	initializeStyles();

--- a/library/src/flexlib/controls/ImageMap.as
+++ b/library/src/flexlib/controls/ImageMap.as
@@ -25,9 +25,10 @@ package flexlib.controls
 {
   import flash.display.Graphics;
   import flash.events.MouseEvent;
-
+  
   import flexlib.events.ImageMapEvent;
-
+  import flexlib.styles.StyleDeclarationHelper;
+  
   import mx.controls.Image;
   import mx.core.FlexGlobals;
   import mx.core.UIComponent;
@@ -190,12 +191,16 @@ package flexlib.controls
     private static function initStyles():Boolean
     {
       var sd:CSSStyleDeclaration =
-        FlexGlobals.topLevelApplication.styleManager.getStyleDeclaration("ImageMap");
+        FlexGlobals.topLevelApplication.styleManager.getStyleDeclaration(
+			StyleDeclarationHelper.getStyleSelectorForClassName("flexlib.controls.ImageMap")
+		);
 
       if (!sd)
       {
         sd = new CSSStyleDeclaration();
-        FlexGlobals.topLevelApplication.styleManager.setStyleDeclaration("ImageMap", sd, false);
+        FlexGlobals.topLevelApplication.styleManager.setStyleDeclaration(
+			StyleDeclarationHelper.getStyleSelectorForClassName("flexlib.controls.ImageMap"), 
+			sd, false);
       }
 
       sd.defaultFactory = function():void

--- a/library/src/flexlib/controls/ScrollableArrowMenu.as
+++ b/library/src/flexlib/controls/ScrollableArrowMenu.as
@@ -29,13 +29,15 @@ package flexlib.controls
 	import flash.events.MouseEvent;
 	import flash.events.TimerEvent;
 	import flash.utils.Timer;
-
+	
+	import flexlib.styles.StyleDeclarationHelper;
+	
 	import mx.controls.Button;
 	import mx.controls.Menu;
 	import mx.controls.scrollClasses.ScrollBar;
 	import mx.core.Application;
-    import mx.core.FlexGlobals;
-    import mx.core.ScrollPolicy;
+	import mx.core.FlexGlobals;
+	import mx.core.ScrollPolicy;
 	import mx.core.mx_internal;
 	import mx.events.ScrollEvent;
 	import mx.styles.CSSStyleDeclaration;
@@ -163,7 +165,9 @@ package flexlib.controls
 		 */
 		private static function initializeStyles():void
 		{
-			var selector:CSSStyleDeclaration = FlexGlobals.topLevelApplication.styleManager.getStyleDeclaration("ScrollableArrowMenu");
+			var selector:CSSStyleDeclaration = FlexGlobals.topLevelApplication.styleManager.getStyleDeclaration(
+				StyleDeclarationHelper.getStyleSelectorForClassName("flexlib.controls.ScrollableArrowMenu")
+			);
 
 			if(!selector)
 			{
@@ -176,7 +180,9 @@ package flexlib.controls
 				this.downButtonStyleName = "downButton";
 			}
 
-			FlexGlobals.topLevelApplication.styleManager.setStyleDeclaration("ScrollableArrowMenu", selector, false);
+			FlexGlobals.topLevelApplication.styleManager.setStyleDeclaration(
+				StyleDeclarationHelper.getStyleSelectorForClassName("flexlib.controls.ScrollableArrowMenu"), 
+				selector, false);
 
 
 

--- a/library/src/flexlib/controls/SuperTabBar.as
+++ b/library/src/flexlib/controls/SuperTabBar.as
@@ -28,20 +28,21 @@ package flexlib.controls {
 	import flash.display.DisplayObject;
 	import flash.events.Event;
 	import flash.events.MouseEvent;
-
+	
 	import flexlib.containers.SuperTabNavigator;
 	import flexlib.controls.tabBarClasses.SuperTab;
 	import flexlib.events.SuperTabEvent;
 	import flexlib.events.TabReorderEvent;
-
+	import flexlib.styles.StyleDeclarationHelper;
+	
 	import mx.collections.IList;
 	import mx.containers.ViewStack;
 	import mx.controls.Button;
 	import mx.controls.TabBar;
 	import mx.core.ClassFactory;
 	import mx.core.DragSource;
-    import mx.core.FlexGlobals;
-    import mx.core.IFlexDisplayObject;
+	import mx.core.FlexGlobals;
+	import mx.core.IFlexDisplayObject;
 	import mx.core.IUIComponent;
 	import mx.core.UIComponent;
 	import mx.core.mx_internal;
@@ -130,7 +131,9 @@ package flexlib.controls {
 
 		private static function initializeStyles():void
 		{
-			var selector:CSSStyleDeclaration = FlexGlobals.topLevelApplication.styleManager.getStyleDeclaration("SuperTabBar");
+			var selector:CSSStyleDeclaration = FlexGlobals.topLevelApplication.styleManager.getStyleDeclaration(
+				StyleDeclarationHelper.getStyleSelectorForClassName("flexlib.controls.SuperTabBar")
+			);
 
 			if(!selector)
 			{
@@ -179,7 +182,9 @@ package flexlib.controls {
 
 			FlexGlobals.topLevelApplication.styleManager.setStyleDeclaration("." + tabCloseStyleName, cSelector, false);
 
-			FlexGlobals.topLevelApplication.styleManager.setStyleDeclaration("SuperTabBar", selector, false);
+			FlexGlobals.topLevelApplication.styleManager.setStyleDeclaration(
+				StyleDeclarationHelper.getStyleSelectorForClassName("flexlib.controls.SuperTabBar"), 
+				selector, false);
 		}
 
 		initializeStyles();

--- a/library/src/flexlib/mdi/containers/MDIWindow.as
+++ b/library/src/flexlib/mdi/containers/MDIWindow.as
@@ -31,16 +31,17 @@ package flexlib.mdi.containers
 	import flash.ui.ContextMenu;
 	import flash.ui.ContextMenuItem;
 	import flash.utils.getQualifiedClassName;
-
+	
 	import flexlib.mdi.events.MDIWindowEvent;
 	import flexlib.mdi.managers.MDIManager;
-
+	import flexlib.styles.StyleDeclarationHelper;
+	
 	import mx.containers.Canvas;
 	import mx.containers.Panel;
 	import mx.controls.Button;
 	import mx.core.Container;
-    import mx.core.FlexGlobals;
-    import mx.core.UIComponent;
+	import mx.core.FlexGlobals;
+	import mx.core.UIComponent;
 	import mx.core.UITextField;
 	import mx.core.mx_internal;
 	import mx.managers.CursorManager;
@@ -569,7 +570,10 @@ package flexlib.mdi.containers
 			//------------------------
 		    //  type selector
 		    //------------------------
-			var selector:CSSStyleDeclaration = FlexGlobals.topLevelApplication.styleManager.getStyleDeclaration("MDIWindow");
+			var selector:CSSStyleDeclaration = FlexGlobals.topLevelApplication.styleManager.getStyleDeclaration(
+				StyleDeclarationHelper.getStyleSelectorForClassName("flexlib.mdi.containers.MDIWindow")
+			);
+			
 			if(!selector)
 			{
 				selector = new CSSStyleDeclaration();
@@ -744,7 +748,9 @@ package flexlib.mdi.containers
 			FlexGlobals.topLevelApplication.styleManager.setStyleDeclaration("." + closeBtnStyleName, closeBtnSelector, false);
 
 			// apply it all
-			FlexGlobals.topLevelApplication.styleManager.setStyleDeclaration("MDIWindow", selector, false);
+			FlexGlobals.topLevelApplication.styleManager.setStyleDeclaration(
+				StyleDeclarationHelper.getStyleSelectorForClassName("flexlib.mdi.containers.MDIWindow"), 
+				selector, false);
 
 			return true;
 		}

--- a/library/src/flexlib/scheduling/ScheduleViewer.as
+++ b/library/src/flexlib/scheduling/ScheduleViewer.as
@@ -31,16 +31,17 @@
  */
 package flexlib.scheduling
 {
+  import flash.events.Event;
+  import flash.events.MouseEvent;
+  
   import flexlib.scheduling.scheduleClasses.IScheduleEntry;
   import flexlib.scheduling.scheduleClasses.LayoutScrollEvent;
   import flexlib.scheduling.scheduleClasses.Schedule;
   import flexlib.scheduling.scheduleClasses.ScheduleNavigator;
   import flexlib.scheduling.scheduleClasses.layout.IEntryLayout;
   import flexlib.scheduling.scheduleClasses.schedule_internal;
-
-  import flash.events.Event;
-  import flash.events.MouseEvent;
-
+  import flexlib.styles.StyleDeclarationHelper;
+  
   import mx.collections.ArrayCollection;
   import mx.collections.ICollectionView;
   import mx.collections.IList;
@@ -256,7 +257,7 @@ package flexlib.scheduling
     // Define a static method to initialize the style.
     private static function classConstruct():Boolean
     {
-      if (!FlexGlobals.topLevelApplication.styleManager.getStyleDeclaration(".scheduleViewer"))
+      if (!FlexGlobals.topLevelApplication.styleManager.getStyleDeclaration(StyleDeclarationHelper.getStyleSelectorForClassName("flexlib.scheduling.ScheduleViewer")))
       {
         // If ScheduleViewer has no CSS definition,
         // create one and set the default value.
@@ -270,7 +271,9 @@ package flexlib.scheduling
         newStyleDeclaration.setStyle("verticalGridLineColor", 0x000000);
         newStyleDeclaration.setStyle("verticalGridLineAlpha", .5);
 
-        FlexGlobals.topLevelApplication.styleManager.setStyleDeclaration(".scheduleViewer", newStyleDeclaration, true);
+        FlexGlobals.topLevelApplication.styleManager.setStyleDeclaration(
+			StyleDeclarationHelper.getStyleSelectorForClassName("flexlib.scheduling.ScheduleViewer"), 
+			newStyleDeclaration, true);
       }
       return true;
     }

--- a/library/src/flexlib/styles/StyleDeclarationHelper.as
+++ b/library/src/flexlib/styles/StyleDeclarationHelper.as
@@ -1,0 +1,46 @@
+package flexlib.styles
+{
+	import flash.utils.getQualifiedClassName;
+	
+	import mx.core.FlexVersion;
+
+	public class StyleDeclarationHelper
+	{
+		
+		/**
+		 * Gets the style selector for the specified class.
+		 * @see getStyleSelectorForClassName
+		 * 
+		 * @param c The component class to get the style selector for
+		 * @return style selector string for given class
+		 * 
+		 */
+		public static function getStyleSelectorForClass(c:Class):String
+		{
+			return getStyleSelectorForClassName(flash.utils.getQualifiedClassName(c));
+		}
+		
+		/**
+		 * Gets the style selector for the specified class name.
+		 * 
+		 * Starting in Flex 4, component selectors passed to StyleManager.getStyleDeclaration and StyleManager.setStyleDeclaration
+		 * must be fully qualified class names. In versions of Flex < 4, the class name itself was used.
+		 * 
+		 * @see http://flexdevtips.blogspot.com/2009/03/setting-default-styles-for-custom.html
+		 * 
+		 * @param fullyQualifiedName The fully qualified name of the class to get the selector for
+		 * @return style selector string
+		 * 
+		 */
+		public static function getStyleSelectorForClassName(fullyQualifiedName:String):String
+		{
+			if (FlexVersion.compatibilityVersion >= FlexVersion.VERSION_4_0)
+				return fullyQualifiedName.replace("::", ".");
+			
+			var classNameStart:int = fullyQualifiedName.lastIndexOf(":");
+			if(classNameStart != -1)
+				return fullyQualifiedName.substr(classNameStart + 1);
+			return fullyQualifiedName;
+		}
+	}
+}


### PR DESCRIPTION
Behaviour of styleManager.setStyleDeclaration changed in flex 4 to require fully qualified namespacing.

See http://flexdevtips.blogspot.com/2009/03/setting-default-styles-for-custom.html for the new namespacing requirement for style declarations.
