### PR TITLE
[Component] :: flexlib.containers.SuperTabNavigator

### DIFF
--- a/library/src/flexlib/containers/SuperTabNavigator.as
+++ b/library/src/flexlib/containers/SuperTabNavigator.as
@@ -48,6 +48,7 @@ package flexlib.containers
   import mx.core.Container;
   import mx.core.EdgeMetrics;
   import mx.core.FlexGlobals;
+  import mx.core.INavigatorContent;
   import mx.core.ScrollPolicy;
   import mx.effects.Tween;
   import mx.events.ChildExistenceChangedEvent;
@@ -1177,7 +1178,7 @@ package flexlib.containers
 
       for (var i:int = 0; i < this.numChildren; i++)
       {
-        var child:Container = this.getChildAt(i) as Container;
+        var child:INavigatorContent = INavigatorContent(this.getChildAt(i));
 
         var obj:Object = new Object();
         //setting the type to an empty string bypasses a bug in MenuItemRenderer (or in

--- a/library/src/flexlib/containers/SuperTabNavigator.as
+++ b/library/src/flexlib/containers/SuperTabNavigator.as
@@ -45,7 +45,6 @@ package flexlib.containers
   import mx.containers.ViewStack;
   import mx.controls.Menu;
   import mx.controls.PopUpButton;
-  import mx.core.Container;
   import mx.core.EdgeMetrics;
   import mx.core.FlexGlobals;
   import mx.core.INavigatorContent;


### PR DESCRIPTION
- Change on the type used on casting of child element from
  [mx.core.Container] to [mx.core.INavigatorContent], according to the
  specification of the [mx.containers.ViewStack] component;
- Also, change on the casting from (Type Checking) with [as] operator
  to (Type Conversion) with [Class(arg)]. 
  With the old class type [mx.core.Container] the casting by type
  checking throw an [TypeError: Error #1009: null has no properties.],
  instead of correct error that should be [TypeError: Error #1034: Type
  Coercion failed: cannot convert %a to %t]
